### PR TITLE
initial version of the bulk API

### DIFF
--- a/api.py
+++ b/api.py
@@ -103,7 +103,7 @@ def bulk():
 
         insert_data(inserts)
 
-    return "bulk"
+    return "OK"
 
 
 def map_input_to_columns(args):

--- a/api.py
+++ b/api.py
@@ -98,7 +98,7 @@ def bulk():
         inserts['time'] = start_time + timedelta(seconds=row[0])
         inserts['site_id'] = row[1]
         for index in app.config["BULK_INDEX_MAPPING"]:
-            if len(row) >= index+1:
+            if len(row) >= index+1: # make sure we have an entry for that index. just in case
                 inserts[app.config['BULK_INDEX_MAPPING'][index]] = row[index]
 
         insert_data(inserts)

--- a/api.py
+++ b/api.py
@@ -8,7 +8,7 @@ import sqlalchemy
 import rollbar
 import rollbar.contrib.flask
 
-from datetime import datetime, date, time
+from datetime import datetime, date, time, timedelta
 from flask import Flask, abort, request, flash, redirect, render_template, url_for, jsonify, got_request_exception
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.datastructures import MultiDict
@@ -24,7 +24,8 @@ app.config.update(dict(
     ENVIRONMENT='development',
     TABLE_NAME='seshdash_bom_data_point',
     APIKEY=None,
-    MAPPING=dict()
+    MAPPING=dict(),
+    BULK_INDEX_MAPPING = dict()
 ))
 app.config.from_envvar('FLASK_SETTINGS', silent=True)
 
@@ -85,18 +86,22 @@ def post():
 
 # accepts an EMON post bulk data command
 # time must be a unix timestamp whereas for the other endpoints we require a UTC string. the reason for this is here we need to calculate with time whereas in the other endpoints we only hand it over to the database (which does not accept a unix timestamp)
-@app.route('/input/bulk', methods=['GET'])
+@app.route('/input/bulk.json', methods=['GET'])
 def bulk():
     if not request.args.get('data', None):
         return ""
     data = json.loads(request.args.get('data'))
 
-    for index in app.config["BULK_INDEX_MAPPING"]:
-        entry = data[index]
-        column = app.config["BULK_INDEX_MAPPING"][index]
+    start_time = datetime.fromtimestamp(int(request.args.get('time')))
+    for row in data:
+        inserts = dict()
+        inserts['time'] = start_time + timedelta(seconds=row[0])
+        inserts['site_id'] = row[1]
+        for index in app.config["BULK_INDEX_MAPPING"]:
+            if len(row) >= index+1:
+                inserts[app.config['BULK_INDEX_MAPPING'][index]] = row[index]
 
-    for entry in data:
-        print entry
+        insert_data(inserts)
 
     return "bulk"
 

--- a/config.cfg.example
+++ b/config.cfg.example
@@ -4,7 +4,8 @@ SECRET_KEY='development'
 ROLLBAR_TOKEN='token'
 LOG_LEVEL='DEBUG'
 ENVIRONMENT='development
-TABLE_NAME='seshdash_bom_data_point',
-APIKEY=None,
-MAPPING=dict(),
+TABLE_NAME='seshdash_bom_data_point'
+APIKEY=None
+MAPPING=dict()
+BULK_INDEX_MAPPING=dict()
 


### PR DESCRIPTION
this is the initial version of a the bulk API. 

it takes a request like `/input/bulk.json?data=[[0,16,1137],[2,17,1437,3164],[4,19,1412,3077]]&time=1231231421&apikey=hello` 
and creates entries for each array entry. 

The array is in the format of `[[time offset, node/site, values, values, ... ], ...]`
The mapping of an array index to a DB column is defined in the `BULK_INDEX_MAPPING` config variable. 

please note: currently it is executing one SQL insert per array entry, so it is not doing any bulk insert right now. 
