### PR TITLE
Multi table node id support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ sdist/
 var/
 *.egg-info/
 .installed.cfg
+*.cfg
 *.egg
 
 # PyInstaller

--- a/api.py
+++ b/api.py
@@ -91,17 +91,22 @@ def post():
 def bulk():
     if not request.args.get('data', None):
         return ""
+    if not request.args.get('site_id', None):
+        return ""
+
     data = json.loads(request.args.get('data'))
+    site_id =  json.loads(request.args.get('site_id'))
 
     start_time = datetime.fromtimestamp(int(request.args.get('time')))
     for row in data:
         inserts = dict()
-        inserts['time'] = start_time + timedelta(seconds=row[0])
-        inserts['site_id'] = row[1]
+        #inserts['time'] = start_time + timedelta(seconds=row[0])
+        inserts['time'] = datetime.fromtimestamp(int(row[0]))
+        inserts['site_id'] = site_id #adding distinction between
         for index in app.config["BULK_INDEX_MAPPING"]:
             if len(row) >= index+1: # make sure we have an entry for that index. just in case
                 inserts[app.config['BULK_INDEX_MAPPING'][index]] = row[index]
-
+        logging.info("inserting %s"%inserts)
         insert_data(inserts)
 
     return "OK"

--- a/api.py
+++ b/api.py
@@ -28,7 +28,7 @@ app.config.update(dict(
     BULK_INDEX_MAPPING = dict(),
     BULK_NODE_TABLE_MAPPING = dict()
 ))
-app.config.from_envvar('FLASK_SETTINGS', silent=False)
+app.config.from_envvar('FLASK_SETTINGS', silent=True)
 logging.basicConfig(level=getattr(logging, app.config['LOG_LEVEL'].upper(), None), filename='logs/' + app.config['ENVIRONMENT'] + '.log')
 
 if app.config['DEBUG']:

--- a/api.py
+++ b/api.py
@@ -103,7 +103,7 @@ def bulk():
         return ""
 
     site_id =  json.loads(request.args.get('site_id'))
-    start_time = datetime.fromtimestamp(int(request.args.get('time')))
+    start_time = datetime.fromtimestamp(int(request.form['time']))
     for row in data:
         inserts = dict()
         inserts['timestamp'] = datetime.fromtimestamp(int(row[0]))

--- a/config.cfg.example
+++ b/config.cfg.example
@@ -6,6 +6,6 @@ LOG_LEVEL='DEBUG'
 ENVIRONMENT='development
 TABLE_NAME='seshdash_bom_data_point'
 APIKEY=None
-MAPPING=dict()
+MAPPING=dict() # {<node_id>:{<index_number>:<mapping_value>...,'table':<table_name>}...}
 BULK_INDEX_MAPPING=dict()
 

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -1,0 +1,1 @@
+export FLASK_SETTINGS=/c/Users/alp/Desktop/dev/sesh-api-helper/sesh-api-helper/config.cfg

--- a/test_api.py
+++ b/test_api.py
@@ -84,8 +84,8 @@ class ApiTestCase(unittest.TestCase):
         print rows2
         assert rows[0][2] == 1137
         assert rows[0][3] == 16
-        assert rows2[1][2] == 1437
-        assert rows2[1][3] == 17
+        assert rows2[0][2] == 1437
+        assert rows2[0][3] == 17
         #TODO: test timestamp
 
 

--- a/test_api.py
+++ b/test_api.py
@@ -64,7 +64,8 @@ class ApiTestCase(unittest.TestCase):
         r = self.app.get('/input/bulk.json?data=[[0,16,1137],[2,17,1437,3164]]&time=1231231421')
         assert 200 == r.status_code
         rows = api.app.engine.execute(api.get_table().select().order_by(sqlalchemy.desc('id'))).fetchall()
-        assert rows[0]['power'] == unicode(1437)
+        print rows
+        assert rows[0]['power'] == 1437
         assert rows[0]['site_id'] == 17
         assert rows[0]['battery_voltage'] == 3164
         assert rows[1]['site_id'] == 16

--- a/test_api.py
+++ b/test_api.py
@@ -72,8 +72,8 @@ class ApiTestCase(unittest.TestCase):
     def test_bulk(self):
         api.app.config['APIKEY'] = 'testing'
         api.app.config['BULK_INDEX_MAPPING'] = {9:{2:'power', 3:'battery_voltage','table':'test_table'},11:{2:'power', 3:'battery_voltage','table':'test_table2'}}
-        r = self.app.post('/input/bulk.json?time=1231231421&site_id=1&apikey='+ api.app.config.get('APIKEY'),
-                data=dict(data='[[121234123,9,16,1137],[2341234,11,17,1437]]'))
+        r = self.app.post('/input/bulk.json?site_id=1&apikey='+ api.app.config.get('APIKEY'),
+                data=dict(data='[[121234123,9,16,1137],[2341234,11,17,1437]]',time=12312415))
         print r
 
         assert 200 == r.status_code

--- a/test_api.py
+++ b/test_api.py
@@ -79,7 +79,9 @@ class ApiTestCase(unittest.TestCase):
         assert 200 == r.status_code
         rows = api.app.engine.execute(api.get_table(api.app.config['TABLE_NAME']).select().order_by(sqlalchemy.desc('id'))).fetchall()
         rows2 = api.app.engine.execute(api.get_table(api.app.config['TABLE_NAME2']).select().order_by(sqlalchemy.desc('id'))).fetchall()
-
+        print rows
+        print "##########"
+        print rows2
         assert rows[0][2] == 1137
         assert rows[0][3] == 16
         assert rows2[1][2] == 1437


### PR DESCRIPTION
Updates:
-  Modified bulk posting to work with different tables. Consequently the BULK_INDEX_MAPPING configuration has changed to reflect a table based on the nodeid. 
- Updated CI testing to reflect this
- Changed Bulkpost to use POST rather than GET, as data getting pushed can get too big for GET.
- site_id is now a mandatory parameter 
- Changed time field to timestamp

TODO:
- Create new end points to handle status messages from RMC unit
- Make mechanism for hardcoded fields better. Site_id, timestamp? Should these be configurable?work with defaults?
