### PR TITLE
[WIP] Add endpoint to collect RMC status information

### DIFF
--- a/api.py
+++ b/api.py
@@ -73,7 +73,7 @@ def init_rollbar():
 
 @app.before_request
 def validate_api_key():
-    apikey = request.args.get('apikey', None)
+    apikey = request.args.get('apikey', request.headers.get('X-Api-Key', None)) # get the API key from a request param or a header
 
     sql = get_table('Sesh_RMC_Account').select().where(sqlalchemy.text('API_KEY = :k')).limit(1)
     result = app.engine.execute(sql, k=apikey)

--- a/test_api.py
+++ b/test_api.py
@@ -74,6 +74,12 @@ class ApiTestCase(unittest.TestCase):
             r = self.app.get(route)
             assert 403 == r.status_code
 
+    def test_apikey_as_header(self):
+        assert 200 == self.app.get('/ping', headers={'X-API-KEY': 'YAYTESTS'}).status_code
+
+    def test_apikey_as_query_param(self):
+        assert 200 == self.app.get('/ping?apikey=YAYTESTS').status_code
+
     def test_insert(self):
         api.app.config['MAPPING'] = dict(pwr='power')
         r = self.app.get('/input/insert?apikey=YAYTESTS&battery_voltage=123&pwr=500&timestamp=2015-12-15T07:36:25Z')


### PR DESCRIPTION
Adding a /status endpoint to collect status information from an RMC.
Data is read from a json request body and stored in a configurable STATUS_TABLE_NAME mysql table.
JSON keys must respect the database schema. (to be define)

ToDo:
- [x] identify RMC by API key - this should also be used for the other endpoints
