### PR TITLE
Fix incoming request parsing (gzip,msgpack,json) for empty bodies

### DIFF
--- a/api.py
+++ b/api.py
@@ -88,6 +88,8 @@ def validate_api_key():
 
 @app.before_request
 def decompress_data():
+    if request.data == "":
+        return
     # Check if compressesed
     if request.headers.get('Content-Encoding', None) == 'gzip':
         request.data = zlib.decompress(request.get_data())


### PR DESCRIPTION
Empty request bodies cased the parsing to fail. We now only parse the
body if it is not empty ("")
